### PR TITLE
Parameterise root and data disk volume types

### DIFF
--- a/modules/oracle-database/main.tf
+++ b/modules/oracle-database/main.tf
@@ -34,8 +34,8 @@ data "template_file" "user_data" {
 locals {
   database_size          = var.db_size["database_size"]
   instance_type          = var.db_size["instance_type"]
-  # disk_type_root       = var.db_size["disk_type_root"]
-  # disk_throughput_root = var.db_size["disk_throughput_root"]
+  disk_type_root       = var.db_size["disk_type_root"]
+  disk_throughput_root = var.db_size["disk_throughput_root"]
   disk_type_data       = var.db_size["disk_type_data"]
   disk_throughput_data = var.db_size["disk_throughput_data"]
   disks_quantity         = var.db_size["disks_quantity"]
@@ -61,7 +61,8 @@ resource "aws_instance" "oracle_db" {
   root_block_device {
     delete_on_termination = true
     volume_size           = 256
-    volume_type           = "io1"
+    volume_type           = local.disk_type_root
+    throughput = local.disk_type_root == "gp3" ? local.disk_throughput_root : null
     iops                  = local.disk_iops_root
   }
 

--- a/modules/oracle-database/main.tf
+++ b/modules/oracle-database/main.tf
@@ -32,20 +32,20 @@ data "template_file" "user_data" {
 }
 
 locals {
-  database_size          = var.db_size["database_size"]
-  instance_type          = var.db_size["instance_type"]
+  database_size        = var.db_size["database_size"]
+  instance_type        = var.db_size["instance_type"]
   disk_type_root       = var.db_size["disk_type_root"]
   disk_throughput_root = var.db_size["disk_throughput_root"]
   disk_type_data       = var.db_size["disk_type_data"]
   disk_throughput_data = var.db_size["disk_throughput_data"]
-  disks_quantity         = var.db_size["disks_quantity"]
-  disks_quantity_data    = var.db_size["disks_quantity_data"]
-  disk_iops_data         = var.db_size["disk_iops_data"]
-  disk_iops_flash        = var.db_size["disk_iops_flash"]
-  disk_iops_root         = var.db_size["disk_iops_root"]
-  disk_size_data         = var.db_size["disk_size_data"]
-  disk_size_flash        = var.db_size["disk_size_flash"]
-  tags_name_prefix       = "${var.environment_name}-${var.server_name}"
+  disks_quantity       = var.db_size["disks_quantity"]
+  disks_quantity_data  = var.db_size["disks_quantity_data"]
+  disk_iops_data       = var.db_size["disk_iops_data"]
+  disk_iops_flash      = var.db_size["disk_iops_flash"]
+  disk_iops_root       = var.db_size["disk_iops_root"]
+  disk_size_data       = var.db_size["disk_size_data"]
+  disk_size_flash      = var.db_size["disk_size_flash"]
+  tags_name_prefix     = "${var.environment_name}-${var.server_name}"
 }
 
 resource "aws_instance" "oracle_db" {
@@ -62,7 +62,7 @@ resource "aws_instance" "oracle_db" {
     delete_on_termination = true
     volume_size           = 256
     volume_type           = local.disk_type_root
-    throughput = local.disk_type_root == "gp3" ? local.disk_throughput_root : null
+    throughput            = local.disk_type_root == "gp3" ? local.disk_throughput_root : null
     iops                  = local.disk_iops_root
   }
 

--- a/modules/oracle-database/main.tf
+++ b/modules/oracle-database/main.tf
@@ -32,16 +32,18 @@ data "template_file" "user_data" {
 }
 
 locals {
-  database_size       = var.db_size["database_size"]
-  instance_type       = var.db_size["instance_type"]
-  disks_quantity      = var.db_size["disks_quantity"]
-  disks_quantity_data = var.db_size["disks_quantity_data"]
-  disk_iops_data      = var.db_size["disk_iops_data"]
-  disk_iops_flash     = var.db_size["disk_iops_flash"]
-  disk_iops_root      = var.db_size["disk_iops_root"]
-  disk_size_data      = var.db_size["disk_size_data"]
-  disk_size_flash     = var.db_size["disk_size_flash"]
-  tags_name_prefix    = "${var.environment_name}-${var.server_name}"
+  database_size          = var.db_size["database_size"]
+  instance_type          = var.db_size["instance_type"]
+  disk_volume_type       = var.db_size["disk_volume_type"]
+  disk_volume_throughput = var.db_size["disk_volume_throughput"]
+  disks_quantity         = var.db_size["disks_quantity"]
+  disks_quantity_data    = var.db_size["disks_quantity_data"]
+  disk_iops_data         = var.db_size["disk_iops_data"]
+  disk_iops_flash        = var.db_size["disk_iops_flash"]
+  disk_iops_root         = var.db_size["disk_iops_root"]
+  disk_size_data         = var.db_size["disk_size_data"]
+  disk_size_flash        = var.db_size["disk_size_flash"]
+  tags_name_prefix       = "${var.environment_name}-${var.server_name}"
 }
 
 resource "aws_instance" "oracle_db" {

--- a/modules/oracle-database/main.tf
+++ b/modules/oracle-database/main.tf
@@ -34,8 +34,10 @@ data "template_file" "user_data" {
 locals {
   database_size          = var.db_size["database_size"]
   instance_type          = var.db_size["instance_type"]
-  disk_volume_type       = var.db_size["disk_volume_type"]
-  disk_volume_throughput = var.db_size["disk_volume_throughput"]
+  # disk_type_root       = var.db_size["disk_type_root"]
+  # disk_throughput_root = var.db_size["disk_throughput_root"]
+  disk_type_data       = var.db_size["disk_type_data"]
+  disk_throughput_data = var.db_size["disk_throughput_data"]
   disks_quantity         = var.db_size["disks_quantity"]
   disks_quantity_data    = var.db_size["disks_quantity_data"]
   disk_iops_data         = var.db_size["disk_iops_data"]

--- a/modules/oracle-database/modules/ebs-volume/main.tf
+++ b/modules/oracle-database/modules/ebs-volume/main.tf
@@ -1,8 +1,9 @@
 resource "aws_ebs_volume" "oracle_db" {
   count             = var.create_volume ? 1 : 0
   availability_zone = var.availability_zone
-  type              = "io1"
+  type              = var.type
   iops              = var.iops
+  throughput        = var.type == "gp3" ? var.throughput : null
   size              = var.size
   encrypted         = var.encrypted
   kms_key_id        = var.kms_key_id

--- a/modules/oracle-database/modules/ebs-volume/variables.tf
+++ b/modules/oracle-database/modules/ebs-volume/variables.tf
@@ -8,9 +8,22 @@ variable "size" {
   default     = 25
 }
 
+variable "type" {
+  description = "The type of EBS volume. Can be standard, gp2, gp3, io1, io2, sc1 or st1 (Default: gp2)"
+  default     = "io1"
+  type        = string
+}
+
+
 variable "iops" {
-  description = "volume iops"
+  description = "The amount of IOPS to provision for the disk. Only valid for type of io1, io2 or gp3."
   default     = 1000
+}
+
+variable "throughput" {
+  description = "The throughput that the volume supports, in MiB/s. Only valid for type of gp3."
+  default     = 125
+  type        = number
 }
 
 variable "instance_id" {

--- a/modules/oracle-database/modules/ebs-volume/variables.tf
+++ b/modules/oracle-database/modules/ebs-volume/variables.tf
@@ -9,7 +9,7 @@ variable "size" {
 }
 
 variable "type" {
-  description = "The type of EBS volume. Can be standard, gp2, gp3, io1, io2, sc1 or st1 (Default: gp2)"
+  description = "The type of EBS volume. Can be standard, gp2, gp3, io1, io2, sc1 or st1"
   default     = "io1"
   type        = string
 }

--- a/modules/oracle-database/volumes.tf
+++ b/modules/oracle-database/volumes.tf
@@ -17,8 +17,8 @@
 # db_size_delius_core = {
 #   database_size  = "x_large"
 #   instance_type  = "r5.4xlarge"
-#   disk_volume_type = "gp3"
-#   disk_volume_throughput = 750 # Only applicable if disk_volume_type = "gp3"
+#   disk_type_data = "gp3"
+#   disk_throughput_data = 750 # Only applicable if disk_type_data = "gp3"
 #   disks_quantity      = 16           # Do not decrease this
 #   disks_quantity_data = 9
 #   disk_iops_data      = 1000
@@ -32,8 +32,8 @@ module "dev_xvdca" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 1 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 1 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 1 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -51,8 +51,8 @@ module "dev_xvdcb" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 2 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 2 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 2 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -70,8 +70,8 @@ module "dev_xvdcc" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 3 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 3 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 3 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -89,8 +89,8 @@ module "dev_xvdcd" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 4 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 4 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 4 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -108,8 +108,8 @@ module "dev_xvdce" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 5 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 5 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 5 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -127,8 +127,8 @@ module "dev_xvdcf" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 6 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 6 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 6 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -146,8 +146,8 @@ module "dev_xvdcg" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 7 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 7 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 7 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -165,8 +165,8 @@ module "dev_xvdch" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 8 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 8 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 8 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -184,8 +184,8 @@ module "dev_xvdci" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 9 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 9 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 9 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -203,8 +203,8 @@ module "dev_xvdcj" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 10 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 10 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 10 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -222,8 +222,8 @@ module "dev_xvdck" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 11 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 11 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 11 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -241,8 +241,8 @@ module "dev_xvdcl" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 12 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 12 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 12 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -260,8 +260,8 @@ module "dev_xvdcm" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 13 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 13 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 13 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -279,8 +279,8 @@ module "dev_xvdcn" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 14 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 14 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 14 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -298,8 +298,8 @@ module "dev_xvdco" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 15 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 15 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 15 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -317,8 +317,8 @@ module "dev_xvdcp" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 16 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 16 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 16 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -336,8 +336,8 @@ module "dev_xvdcq" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 17 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 17 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 17 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -355,8 +355,8 @@ module "dev_xvdcr" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 18 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 18 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 18 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -374,8 +374,8 @@ module "dev_xvdcs" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 19 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 19 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 19 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -393,8 +393,8 @@ module "dev_xvdct" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 20 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 20 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 20 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -412,8 +412,8 @@ module "dev_xvdcu" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 21 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 21 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 21 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -431,8 +431,8 @@ module "dev_xvdcv" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 22 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 22 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 22 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -450,8 +450,8 @@ module "dev_xvdcw" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 23 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 23 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 23 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -469,8 +469,8 @@ module "dev_xvdcx" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 24 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
-  type              = local.disk_volume_type
-  throughput        = local.disk_volume_throughput # only relevant for gp3
+  type              = local.disk_type_data
+  throughput        = local.disk_throughput_data # only relevant for gp3
   iops              = local.disks_quantity_data >= 24 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 24 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id

--- a/modules/oracle-database/volumes.tf
+++ b/modules/oracle-database/volumes.tf
@@ -51,6 +51,8 @@ module "dev_xvdcb" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 2 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 2 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 2 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -68,6 +70,8 @@ module "dev_xvdcc" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 3 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 3 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 3 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -85,6 +89,8 @@ module "dev_xvdcd" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 4 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 4 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 4 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -102,6 +108,8 @@ module "dev_xvdce" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 5 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 5 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 5 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -119,6 +127,8 @@ module "dev_xvdcf" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 6 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 6 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 6 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -136,6 +146,8 @@ module "dev_xvdcg" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 7 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 7 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 7 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -153,6 +165,8 @@ module "dev_xvdch" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 8 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 8 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 8 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -170,6 +184,8 @@ module "dev_xvdci" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 9 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 9 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 9 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -187,6 +203,8 @@ module "dev_xvdcj" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 10 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 10 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 10 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -204,6 +222,8 @@ module "dev_xvdck" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 11 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 11 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 11 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -221,6 +241,8 @@ module "dev_xvdcl" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 12 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 12 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 12 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -238,6 +260,8 @@ module "dev_xvdcm" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 13 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 13 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 13 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -255,6 +279,8 @@ module "dev_xvdcn" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 14 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 14 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 14 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -272,6 +298,8 @@ module "dev_xvdco" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 15 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 15 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 15 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -289,6 +317,8 @@ module "dev_xvdcp" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 16 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 16 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 16 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -306,6 +336,8 @@ module "dev_xvdcq" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 17 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 17 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 17 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -323,6 +355,8 @@ module "dev_xvdcr" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 18 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 18 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 18 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -340,6 +374,8 @@ module "dev_xvdcs" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 19 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 19 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 19 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -357,6 +393,8 @@ module "dev_xvdct" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 20 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 20 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 20 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -374,6 +412,8 @@ module "dev_xvdcu" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 21 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 21 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 21 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -391,6 +431,8 @@ module "dev_xvdcv" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 22 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 22 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 22 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -408,6 +450,8 @@ module "dev_xvdcw" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 23 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 23 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 23 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id
@@ -425,6 +469,8 @@ module "dev_xvdcx" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 24 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 24 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 24 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id

--- a/modules/oracle-database/volumes.tf
+++ b/modules/oracle-database/volumes.tf
@@ -15,17 +15,20 @@
 # For this reason we shall enable up to 24 as the base AMI will have 2 already attached.
 
 # db_size_delius_core = {
-#   database_size  = "x_large"
-#   instance_type  = "r5.4xlarge"
-#   disk_type_data = "gp3"
-#   disk_throughput_data = 750 # Only applicable if disk_type_data = "gp3"
-#   disks_quantity      = 16           # Do not decrease this
-#   disks_quantity_data = 9
-#   disk_iops_data      = 1000
-#   disk_iops_flash     = 500
-#   disk_size_data      = 1000 # Do not decrease this
-#   disk_size_flash     = 1000 # Do not decrease this
-#   # total_storage  = 16000 # This should equal disks_quantity x disk_size
+#   database_size        = "x_large"
+#   instance_type        = "r5.4xlarge"
+#   disk_type_data       = "io1" # Requires iops and throughput to be set
+#   disk_throughput_data = 750 # Only relevant when disks_volume_type = "gp3"
+#   disk_type_root       = "io1" # Requires iops and throughput to be set
+#   disk_throughput_root = 125 # Only relevant when disks_volume_type = "gp3"
+#   disks_quantity       = 16 # Do not decrease this
+#   disks_quantity_data  = 10
+#   disk_iops_root       = 1000
+#   disk_iops_data       = 1000
+#   disk_iops_flash      = 500
+#   disk_size_data       = 1000 # Do not decrease this
+#   disk_size_flash      = 1000 # Do not decrease this
+#   ## total_storage     = 16000 # This should equal disks_quantity x disk_size
 # }
 
 module "dev_xvdca" {

--- a/modules/oracle-database/volumes.tf
+++ b/modules/oracle-database/volumes.tf
@@ -17,7 +17,8 @@
 # db_size_delius_core = {
 #   database_size  = "x_large"
 #   instance_type  = "r5.4xlarge"
-#
+#   disk_volume_type = "gp3"
+#   disk_volume_throughput = 750 # Only applicable if disk_volume_type = "gp3"
 #   disks_quantity      = 16           # Do not decrease this
 #   disks_quantity_data = 9
 #   disk_iops_data      = 1000
@@ -31,6 +32,8 @@ module "dev_xvdca" {
   source            = "./modules/ebs-volume"
   create_volume     = local.disks_quantity >= 1 ? true : false
   availability_zone = aws_instance.oracle_db.availability_zone
+  type              = local.disk_volume_type
+  throughput        = local.disk_volume_throughput # only relevant for gp3
   iops              = local.disks_quantity_data >= 1 ? local.disk_iops_data : local.disk_iops_flash
   size              = local.disks_quantity_data >= 1 ? local.disk_size_data : local.disk_size_flash
   kms_key_id        = var.kms_key_id


### PR DESCRIPTION
Work item https://dsdmoj.atlassian.net/browse/NIT-161

Changes to allow variables to drive the volume type for both root and data volumes.
This is associated with a corresponding change to env_config data - see https://github.com/ministryofjustice/hmpps-env-configs/pull/2004
And the delius-db consumers of this module will need to have their terraform module version refs incremented to get the benefit of this change.

See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html for types and required parameters. E.g. gp3 needs a baseline of 3000 IOPS and a throughput settting (at least 125)

New variables:
  disk_type_root: type of volume for root volume, e.g. gp2, gp3, io1 etc. 
  disk_throughput_root: throughput for root volume (only applicable if type is gp3)
  disk_type_data: type of volume for data volume, e.g. gp2, gp3, io1 etc. 
  disk_throughput_data: throughput for data volume (only applicable if type is gp3)
